### PR TITLE
Part of DEV-1083 better handling of INI file for mysql client

### DIFF
--- a/config/mysql_defaults_extra.ini
+++ b/config/mysql_defaults_extra.ini
@@ -1,3 +1,0 @@
-[client]
-user="ht_rights"
-password="ht_rights"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,6 @@ services:
       # TODO: construct this based on the above variables
       HATHIFILES_MYSQL_CONNECTION: "mysql2://ht_rights:ht_rights@mariadb/ht"
       HATHIFILES_DIR: "/usr/src/app/spec/data"
-
     volumes:
       - .:/usr/src/app
       - gem_cache:/gems

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,10 +2,16 @@ services:
   test:
     build: .
     environment:
+      # Used by dumper.rb
+      HATHIFILES_MYSQL_USER: "ht_rights"
+      HATHIFILES_MYSQL_PASSWORD: "ht_rights"
+      HATHIFILES_MYSQL_HOST: "mariadb"
+      HATHIFILES_MYSQL_DATABASE: "ht"
+      # Used by connection.rb
+      # TODO: construct this based on the above variables
       HATHIFILES_MYSQL_CONNECTION: "mysql2://ht_rights:ht_rights@mariadb/ht"
       HATHIFILES_DIR: "/usr/src/app/spec/data"
-      DB_HOST: "mariadb"
-      DB_DATABASE: "ht"
+
     volumes:
       - .:/usr/src/app
       - gem_cache:/gems

--- a/exe/hathifiles_database_full
+++ b/exe/hathifiles_database_full
@@ -24,6 +24,9 @@ end
 
 connection = HathifilesDatabase.new(ENV["HATHIFILES_MYSQL_CONNECTION"])
 Dir.mktmpdir do |tempdir|
-  monthly = HathifilesDatabase::MonthlyUpdate.new(connection: connection, hathifile: hathifile, output_directory: tempdir)
-  monthly.run
+  HathifilesDatabase::MonthlyUpdate.new(
+    connection: connection,
+    hathifile: hathifile,
+    output_directory: tempdir
+  ).run
 end

--- a/lib/hathifiles_database/db/writer.rb
+++ b/lib/hathifiles_database/db/writer.rb
@@ -51,7 +51,7 @@ module HathifilesDatabase
         end
 
         def write(line)
-          @maintable.puts line.maintable_data.join("\t")
+          @maintable.puts line_to_hathifiles_format(line.maintable_data).join("\t")
           htid = line.htid
           line.foreign_table_data.each_pair do |tablename, data|
             data.each do |d|
@@ -82,6 +82,12 @@ module HathifilesDatabase
           else
             "_" + DateTime.now.strftime("%Y%m%d_%H%M")
           end
+        end
+
+        # Translates maintable access field from 1/0 to "allow"/"deny" if possible
+        def line_to_hathifiles_format(line)
+          line[1] = {0 => "deny", 1 => "allow"}[line[1]] || line[1]
+          line
         end
 
         private_class_method :create_suffix

--- a/lib/hathifiles_database/dumper.rb
+++ b/lib/hathifiles_database/dumper.rb
@@ -57,7 +57,7 @@ module HathifilesDatabase
     # No need to do an ORDER BY as we postprocess output using the `sort` command.
     def dump_sql
       # gsub to collapse newlines and multiple space into one line
-      @dump_sql ||= <<~END_SQL.gsub(/\s+/, " ")
+      @dump_sql ||= <<~END_SQL
         SELECT
           htid, IF(access=1, "allow", "deny"), rights_code, bib_num, description, source,
           source_bib_num, oclc, isbn, issn, lccn, title, imprint, rights_reason,

--- a/lib/hathifiles_database/dumper.rb
+++ b/lib/hathifiles_database/dumper.rb
@@ -13,10 +13,10 @@ module HathifilesDatabase
     # Used for constructing the delta between a monthly hathifile and the current
     # state of the database.
     def dump_current(output_file:)
+      # Write credentials to tempfile. Will be cleaned up when block ends.
       # Tempfile is created with 0600 permissions.
       Tempfile.create(["mysql_defaults_extra", ".ini"]) do |ini|
         connection.logger.debug "writing MySQL INI file at #{ini.path}"
-        # Write credentials to temp dir. Will be cleaned up when block ends.
         ini.write(mysql_ini)
         ini.flush
         cmd = dump_cmd(ini_file: ini.path, output_file: output_file)

--- a/lib/hathifiles_database/dumper.rb
+++ b/lib/hathifiles_database/dumper.rb
@@ -53,8 +53,8 @@ module HathifilesDatabase
     def mysql_ini
       <<~END_INI
         [client]
-        user="#{ENV['HATHIFILES_MYSQL_USER']}"
-        password="#{ENV['HATHIFILES_MYSQL_PASSWORD']}"
+        user="#{ENV["HATHIFILES_MYSQL_USER"]}"
+        password="#{ENV["HATHIFILES_MYSQL_PASSWORD"]}"
       END_INI
     end
 

--- a/lib/hathifiles_database/dumper.rb
+++ b/lib/hathifiles_database/dumper.rb
@@ -13,7 +13,7 @@ module HathifilesDatabase
     # Used for constructing the delta between a monthly hathifile and the current
     # state of the database.
     def dump_current(output_file:)
-      # Temp directory is created with 0700 permissions.
+      # Tempfile is created with 0600 permissions.
       Tempfile.create(["mysql_defaults_extra", ".ini"]) do |ini|
         connection.logger.debug "writing MySQL INI file at #{ini.path}"
         # Write credentials to temp dir. Will be cleaned up when block ends.

--- a/lib/hathifiles_database/monthly_update.rb
+++ b/lib/hathifiles_database/monthly_update.rb
@@ -56,7 +56,7 @@ module HathifilesDatabase
     end
 
     # Creates .additions file with only the records added or changed in new_dump
-    # but not current_dump. This file can be directly loaded by MariaDB.
+    # but not current_dump. This file can be loaded just like an ordinary daily update.
     # @return [String] path to additions file
     def additions
       @additions ||= hathifile_derivative("additions").tap do |output_file|

--- a/lib/hathifiles_database/monthly_update.rb
+++ b/lib/hathifiles_database/monthly_update.rb
@@ -35,7 +35,7 @@ module HathifilesDatabase
     # @return [String] path to sorted dump of the current hf database
     def current_dump
       @current_dump ||= File.join(output_directory, "hf_current.txt").tap do |output_file|
-        Tempfile.open("hf_current") do |tempfile|
+        Tempfile.create("hf_current") do |tempfile|
           connection.logger.info "dumping current hf table to #{tempfile.path}"
           dumper.dump_current(output_file: tempfile.path)
           tempfile.flush


### PR DESCRIPTION
- Write credentials to tempfile based on ENV
- Remove `config/mysql_defaults_extra.ini`
- Requires hathifiles-database secret/ENV with connection string broken into individual variables