### PR TITLE
Make sure ENV credentials are escaped, and guard against logger leakage

### DIFF
--- a/exe/hathifiles_database_full_update
+++ b/exe/hathifiles_database_full_update
@@ -6,7 +6,9 @@
 
 $LOAD_PATH.unshift "../lib"
 
+require "cgi"
 require "dotenv"
+require "logger"
 require "pathname"
 require "push_metrics"
 require "tmpdir"
@@ -16,7 +18,30 @@ require "hathifiles_database"
 envfile = Pathname.new(__dir__).parent + ".env"
 Dotenv.load(envfile)
 
-connection = HathifilesDatabase.new(ENV["HATHIFILES_MYSQL_CONNECTION"])
+# This is the "right" way to do the connection if there is a chance the password
+# will contain non-URI-safe characters (as is likely to be the case).
+# We are careful not to let the URI::InvalidURIError backtrace get logged since
+# it can disclose the password.
+# In future we should have a HathifilesDatabase::DB::Connection implementation that
+# passes the individual ENV bits to Sequel, then we can deprecate the use of a connection
+# string/URI.
+
+# See https://github.com/hathitrust/rights_database/blob/main/lib/rights_database/db.rb
+# for a representative implementation.
+
+mysql_user = ENV["HATHIFILES_MYSQL_USER"]
+mysql_password = CGI.escape ENV["HATHIFILES_MYSQL_PASSWORD"]
+mysql_host = ENV["HATHIFILES_MYSQL_HOST"]
+mysql_database = ENV["HATHIFILES_MYSQL_DATABASE"]
+connection_uri = "mysql2://#{mysql_user}:#{mysql_password}@#{mysql_host}/#{mysql_database}"
+
+begin
+  connection = HathifilesDatabase.new(connection_uri)
+rescue URI::InvalidURIError
+  Logger.new($stderr).fatal("invalid URI in database connection string")
+  exit 1
+end
+
 hathifiles = HathifilesDatabase::Hathifiles.new(
   hathifiles_directory: ENV["HATHIFILES_DIR"],
   connection: connection

--- a/lib/hathifiles_database/version.rb
+++ b/lib/hathifiles_database/version.rb
@@ -1,3 +1,3 @@
 module HathifilesDatabase
-  VERSION = "0.4.0"
+  VERSION = "0.4.1"
 end


### PR DESCRIPTION
- Discontinue use of `HATHIFILES_MYSQL_CONNECTION` and instead craft the connection URI with `HATHIFILES_MYSQL_USER` and friends.
  - Percent-escape the password to avoid `URI::InvalidURIError`.
- Further protect against credential leakage by rescuing `URI::InvalidURIError` in the calling app.
- See #21 for next steps, out of scope for this fix.