### PR TITLE
Dependency updates for May 2026

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.4
+FROM ruby:4.0
 
 RUN apt-get update -yqq && apt-get install -yqq --no-install-recommends \
   mariadb-client

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,16 +1,16 @@
 GIT
   remote: https://github.com/hathitrust/push_metrics.git
-  revision: 3cba728a95eb936fed5f06da028c88d06bb23996
+  revision: 197dacfa9da68059012809cb6108691da7b605f6
   branch: main
   specs:
-    push_metrics (0.10.0)
+    push_metrics (0.10.1)
       milemarker (~> 1.0)
       prometheus-client (~> 4.0)
 
 PATH
   remote: .
   specs:
-    hathifiles_database (0.5.5)
+    hathifiles_database (0.5.6)
       date_named_file
       dotenv
       ettin
@@ -26,7 +26,7 @@ GEM
   specs:
     ast (2.4.3)
     base64 (0.3.0)
-    bigdecimal (4.0.1)
+    bigdecimal (4.1.2)
     coderay (1.1.3)
     date (3.5.1)
     date_named_file (0.1.1)
@@ -37,10 +37,10 @@ GEM
     dry-cli (1.4.1)
     dry-files (1.1.0)
     dry-inflector (1.3.1)
-    erb (6.0.1)
+    erb (6.0.4)
     ettin (1.3.0)
       deep_merge
-    hanami-cli (2.3.4)
+    hanami-cli (2.3.5)
       bundler (>= 2.1)
       dry-cli (~> 1.0, >= 1.1.0)
       dry-files (~> 1.0, >= 1.0.2)
@@ -50,11 +50,12 @@ GEM
       rake (~> 13.0)
       zeitwerk (~> 2.6)
     io-console (0.8.2)
-    irb (1.16.0)
+    irb (1.18.0)
       pp (>= 0.6.0)
+      prism (>= 1.3.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
-    json (2.18.0)
+    json (2.19.5)
     language_server-protocol (3.17.0.5)
     library_stdnums (1.6.0)
     lint_roller (1.1.0)
@@ -64,8 +65,8 @@ GEM
       logger
     mysql2 (0.5.7)
       bigdecimal
-    parallel (1.27.0)
-    parser (3.3.10.1)
+    parallel (1.28.0)
+    parser (3.3.11.1)
       ast (~> 2.4.1)
       racc
     pastel (0.8.0)
@@ -84,16 +85,16 @@ GEM
       date
       stringio
     racc (1.8.1)
-    rack (3.2.4)
+    rack (3.2.6)
     rackup (2.3.1)
       rack (>= 3)
     rainbow (3.1.1)
-    rake (13.3.1)
-    rdoc (7.1.0)
+    rake (13.4.2)
+    rdoc (7.2.0)
       erb
       psych (>= 4.0.0)
       tsort
-    regexp_parser (2.11.3)
+    regexp_parser (2.12.0)
     reline (0.6.3)
       io-console (~> 0.5)
     rspec (3.13.2)
@@ -105,11 +106,11 @@ GEM
     rspec-expectations (3.13.5)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
-    rspec-mocks (3.13.7)
+    rspec-mocks (3.13.8)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-support (3.13.7)
-    rubocop (1.82.1)
+    rubocop (1.84.2)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)
@@ -117,10 +118,10 @@ GEM
       parser (>= 3.3.0.2)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 2.9.3, < 3.0)
-      rubocop-ast (>= 1.48.0, < 2.0)
+      rubocop-ast (>= 1.49.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 4.0)
-    rubocop-ast (1.49.0)
+    rubocop-ast (1.49.1)
       parser (>= 3.3.7.2)
       prism (~> 1.7)
     rubocop-performance (1.26.1)
@@ -128,7 +129,7 @@ GEM
       rubocop (>= 1.75.0, < 2.0)
       rubocop-ast (>= 1.47.1, < 2.0)
     ruby-progressbar (1.13.0)
-    sequel (5.101.0)
+    sequel (5.104.0)
       bigdecimal
     simplecov (0.22.0)
       docile (~> 1.1)
@@ -137,12 +138,12 @@ GEM
     simplecov-html (0.13.2)
     simplecov-lcov (0.9.0)
     simplecov_json_formatter (0.1.4)
-    sqlite3 (2.9.0-aarch64-linux-gnu)
-    sqlite3 (2.9.0-x86_64-linux-gnu)
-    standard (1.53.0)
+    sqlite3 (2.9.3-aarch64-linux-gnu)
+    sqlite3 (2.9.3-x86_64-linux-gnu)
+    standard (1.54.0)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.0)
-      rubocop (~> 1.82.0)
+      rubocop (~> 1.84.0)
       standard-custom (~> 1.0.0)
       standard-performance (~> 1.8)
     standard-custom (1.0.2)
@@ -167,8 +168,8 @@ GEM
       unicode-emoji (~> 4.1)
     unicode-emoji (4.2.0)
     wisper (2.0.1)
-    yard (0.9.38)
-    zeitwerk (2.7.4)
+    yard (0.9.43)
+    zeitwerk (2.7.5)
 
 PLATFORMS
   aarch64-linux
@@ -176,12 +177,12 @@ PLATFORMS
 
 DEPENDENCIES
   bigdecimal
-  bundler (~> 2.0)
+  bundler
   hathifiles_database!
   pry
   push_metrics!
-  rake (~> 13.0)
-  rspec (~> 3.0)
+  rake
+  rspec
   simplecov
   simplecov-lcov
   standard

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2019-2025, Regents of the University of Michigan. All rights
+Copyright (c) 2019-2026, Regents of the University of Michigan. All rights
 reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/exe/hathifiles_database_full_update
+++ b/exe/hathifiles_database_full_update
@@ -8,7 +8,6 @@ $LOAD_PATH.unshift "../lib"
 
 require "dotenv"
 require "logger"
-require "pathname"
 require "push_metrics"
 require "tmpdir"
 

--- a/hathifiles_database.gemspec
+++ b/hathifiles_database.gemspec
@@ -25,9 +25,9 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 2.0"
-  spec.add_development_dependency "rake", "~> 13.0"
-  spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "bundler"
+  spec.add_development_dependency "rake"
+  spec.add_development_dependency "rspec"
   spec.add_development_dependency "pry"
   spec.add_development_dependency "yard"
 

--- a/lib/hathifiles_database/version.rb
+++ b/lib/hathifiles_database/version.rb
@@ -1,3 +1,3 @@
 module HathifilesDatabase
-  VERSION = "0.5.6"
+  VERSION = "0.5.7"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,4 @@
 require "bundler/setup"
-require "pathname"
 require "simplecov"
 require "simplecov-lcov"
 


### PR DESCRIPTION
- Ruby 3.4 -> 4.0
- `bundle update --bundler`
- `bundle update --all`
- Fix a couple of unnecessary `require`s flagged by `standardrb`
- Un-pin a couple of development/test gems in the gemspec
- `version.rb` bump
- Increment LICENSE year