### PR TITLE
ETT-1524: Generate summary table from hathifiles

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,7 @@ GIT
 PATH
   remote: .
   specs:
-    hathifiles_database (0.5.6)
+    hathifiles_database (0.5.7)
       date_named_file
       dotenv
       ettin
@@ -189,4 +189,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.7.2
+  4.0.14

--- a/exe/refresh_summary_table
+++ b/exe/refresh_summary_table
@@ -1,0 +1,87 @@
+#!/usr/bin/env ruby
+
+# Refresh summary tables for hathifiles for use for analytics, dashboard, etc.
+
+require "dotenv"
+require "push_metrics"
+
+$LOAD_PATH.unshift "../lib"
+
+require "hathifiles_database"
+require "hathifiles_database/translation_maps"
+
+envfile = Pathname.new(__dir__).parent + ".env"
+Dotenv.load(envfile)
+
+connection = HathifilesDatabase.new
+
+db = connection.rawdb
+
+tracker = PushMetrics.new(
+  job_name: ENV.fetch("HATHIFILES_DATABASE_JOB_NAME", "hathifiles_summary_table_refresh"),
+  logger: connection.logger
+)
+
+HathifilesDatabase::TranslationMaps.new(connection).ensure_tables
+
+connection.logger.info("Updating summary table")
+
+db.run <<~EOT
+  CREATE OR REPLACE TABLE hf_summary_refresh AS
+  SELECT content_provider_code, rights_code, digitization_agent_code,
+         pub_place, bib_fmt, lang_code, rights_date_used,
+         us_gov_doc_flag,
+         count(*) AS item_count, count(distinct bib_num) AS title_count
+  FROM hf
+  GROUP BY content_provider_code, rights_code,
+           digitization_agent_code, pub_place, bib_fmt,
+           lang_code, rights_date_used, us_gov_doc_flag;
+EOT
+
+connection.logger.info("Updating expanded summary table")
+
+db.run <<~EOT
+  CREATE OR REPLACE TABLE hf_summary_expanded_refresh AS
+
+  SELECT
+    bib_fmt.name as format,
+    dep_inst.name as depositing_library,
+    coalesce(language_codes.name,"Unknown") as language,
+    rights_date_used as published_year,
+    rights_code as rights_status,
+    coalesce(pub_place.name,"Unknown") as publication_place,
+    dig_source.dscr as digitization_agent,
+    us_gov_doc_flag,
+    item_count as total_items,
+    title_count as total_unique_titles
+
+  FROM
+    hf_summary_refresh hfs
+      LEFT OUTER JOIN place_of_publication pub_place ON hfs.pub_place = pub_place.code
+      LEFT OUTER JOIN language_codes ON hfs.lang_code = language_codes.code
+      INNER JOIN bib_fmt ON hfs.bib_fmt = bib_fmt.code
+      INNER JOIN ht.ht_institutions dep_inst ON hfs.content_provider_code = dep_inst.inst_id
+      INNER JOIN ht.sources dig_source ON hfs.digitization_agent_code = dig_source.name;
+EOT
+
+connection.logger.info("Dropping old summary tables")
+
+db.run <<~EOT
+  DROP TABLE IF EXISTS hf_summary_old, hf_summary_expanded_old;
+EOT
+
+connection.logger.info("Swapping in new tables")
+
+# Rename will fail if these tables aren't present
+db.create_table?("hf_summary") { String :placeholder }
+db.create_table?("hf_summary_expanded") { String :placeholder }
+
+db.run <<~EOT
+  RENAME TABLE 
+   hf_summary TO hf_summary_old, 
+   hf_summary_refresh TO hf_summary,
+   hf_summary_expanded TO hf_summary_expanded_old,
+   hf_summary_expanded_refresh TO hf_summary_expanded
+EOT
+
+tracker.log_final_line

--- a/lib/hathifiles_database/translation_maps.rb
+++ b/lib/hathifiles_database/translation_maps.rb
@@ -1,0 +1,38 @@
+require "yaml"
+
+module HathifilesDatabase
+  class TranslationMaps
+    MAPPING_TABLES = [:language_codes, :place_of_publication, :bib_fmt]
+
+    def initialize(connection)
+      @db = connection.rawdb
+    end
+
+    def ensure_tables
+      MAPPING_TABLES.each do |table|
+        next if @db.table_exists?(table)
+
+        @db.create_table(table, collate: "utf8_general_ci", charset: "utf8") do
+          String :code, primary_key: true, fixed: true, size: 3
+          String :name
+        end
+
+        load_data(table)
+      end
+    end
+
+    def load_data(table)
+      @db.transaction do
+        mapping = YAML.load_file(File.dirname(__FILE__) + "/translation_maps/#{table}.yaml")
+        @db[table].delete
+        mapping.each do |code, name|
+          @db[table].insert(code: code, name: name)
+        end
+      end
+    end
+
+    def refresh
+      MAPPING_TABLES.each { |t| load_data(t) }
+    end
+  end
+end

--- a/lib/hathifiles_database/translation_maps/bib_fmt.yaml
+++ b/lib/hathifiles_database/translation_maps/bib_fmt.yaml
@@ -1,0 +1,8 @@
+BK: Book
+CF: Computer File
+MP: Map
+MU: Musical Score
+MX: Mixed Materials
+SE: Serial
+VM: Visual Materials
+XX: Unknown/Other

--- a/lib/hathifiles_database/translation_maps/language_codes.yaml
+++ b/lib/hathifiles_database/translation_maps/language_codes.yaml
@@ -1,0 +1,516 @@
+---
+abk: Abkhaz
+ace: Achinese
+ach: Acoli
+ada: Adangme
+ady: Adygei
+aar: Afar
+afh: Afrihili (Artificial language)
+afr: Afrikaans
+afa: Afroasiatic (Other)
+ain: Ainu
+aka: Akan
+akk: Akkadian
+alb: Albanian
+ale: Aleut
+alg: Algonquian (Other)
+ajm: Aljamía
+alt: Altai
+tut: Altaic (Other)
+amh: Amharic
+anp: Angika
+apa: Apache languages
+ara: Arabic
+arg: Aragonese
+arc: Aramaic
+arp: Arapaho
+arw: Arawak
+arm: Armenian
+rup: Aromanian
+art: Artificial (Other)
+asm: Assamese
+ath: Athapascan (Other)
+aus: Australian languages
+map: Austronesian (Other)
+ava: Avaric
+ave: Avestan
+awa: Awadhi
+aym: Aymara
+aze: Azerbaijani
+ast: Bable
+ban: Balinese
+bat: Baltic (Other)
+bal: Baluchi
+bam: Bambara
+bai: Bamileke languages
+bad: Banda languages
+bnt: Bantu (Other)
+bas: Basa
+bak: Bashkir
+baq: Basque
+btk: Batak
+bej: Beja
+bel: Belarusian
+bem: Bemba
+ben: Bengali
+ber: Berber (Other)
+bho: Bhojpuri
+bih: Bihari (Other)
+bik: Bikol
+byn: Bilin
+bis: Bislama
+zbl: Blissymbolics
+bos: Bosnian
+bra: Braj
+bre: Breton
+bug: Bugis
+bul: Bulgarian
+bua: Buriat
+bur: Burmese
+cad: Caddo
+car: Carib
+cat: Catalan
+cau: Caucasian (Other)
+ceb: Cebuano
+cel: Celtic (Other)
+cai: Central American Indian (Other)
+chg: Chagatai
+cmc: Chamic languages
+cha: Chamorro
+che: Chechen
+chr: Cherokee
+chy: Cheyenne
+chb: Chibcha
+chi: Chinese
+chn: Chinook jargon
+chp: Chipewyan
+cho: Choctaw
+chu: Church Slavic
+chk: Chuukese
+chv: Chuvash
+cop: Coptic
+cor: Cornish
+cos: Corsican
+cre: Cree
+mus: Creek
+crp: Creoles and Pidgins (Other)
+cpe: "Creoles and Pidgins, English-based (Other)"
+cpf: "Creoles and Pidgins, French-based (Other)"
+cpp: "Creoles and Pidgins, Portuguese-based (Other)"
+crh: Crimean Tatar
+hrv: Croatian
+scr: Croatian
+cus: Cushitic (Other)
+cze: Czech
+dak: Dakota
+dan: Danish
+dar: Dargwa
+day: Dayak
+del: Delaware
+din: Dinka
+div: Divehi
+doi: Dogri
+dgr: Dogrib
+dra: Dravidian (Other)
+dua: Duala
+dut: Dutch
+dum: "Dutch, Middle (ca. 1050-1350)"
+dyu: Dyula
+dzo: Dzongkha
+frs: East Frisian
+bin: Edo
+efi: Efik
+egy: Egyptian
+eka: Ekajuk
+elx: Elamite
+eng: English
+enm: "English, Middle (1100-1500)"
+ang: "English, Old (ca. 450-1100)"
+myv: Erzya
+esk: Eskimo languages
+epo: Esperanto
+esp: Esperanto
+est: Estonian
+gez: Ethiopic
+eth: Ethiopic
+ewe: Ewe
+ewo: Ewondo
+fan: Fang
+fat: Fanti
+fao: Faroese
+far: Faroese
+fij: Fijian
+fil: Filipino
+fin: Finnish
+fiu: Finno-Ugrian (Other)
+fon: Fon
+fre: French
+frm: "French, Middle (ca. 1300-1600)"
+fro: "French, Old (ca. 842-1300)"
+fry: Frisian
+fri: Frisian
+fur: Friulian
+ful: Fula
+gaa: Gã
+glg: Galician
+gag: Galician
+lug: Ganda
+gay: Gayo
+gba: Gbaya
+geo: Georgian
+ger: German
+gmh: "German, Middle High (ca. 1050-1500)"
+goh: "German, Old High (ca. 750-1050)"
+gem: Germanic (Other)
+gil: Gilbertese
+gon: Gondi
+gor: Gorontalo
+got: Gothic
+grb: Grebo
+grc: "Greek, Ancient (to 1453)"
+gre: "Greek, Modern (1453- )"
+grn: Guarani
+gua: Guarani
+guj: Gujarati
+gwi: Gwich'in
+hai: Haida
+hat: Haitian French Creole
+hau: Hausa
+haw: Hawaiian
+heb: Hebrew
+her: Herero
+hil: Hiligaynon
+hin: Hindi
+hmo: Hiri Motu
+hit: Hittite
+hmn: Hmong
+hun: Hungarian
+hup: Hupa
+iba: Iban
+ice: Icelandic
+ido: Ido
+ibo: Igbo
+ijo: Ijo
+ilo: Iloko
+smn: Inari Sami
+inc: Indic (Other)
+ine: Indo-European (Other)
+ind: Indonesian
+inh: Ingush
+ina: Interlingua (International Auxiliary Language Association)
+int: Interlingua (International Auxiliary Language Association)
+ile: Interlingue
+iku: Inuktitut
+ipk: Inupiaq
+ira: Iranian (Other)
+gle: Irish
+iri: Irish
+mga: "Irish, Middle (ca. 1100-1550)"
+sga: "Irish, Old (to 1100)"
+iro: Iroquoian (Other)
+ita: Italian
+jpn: Japanese
+jav: Javanese
+jrb: Judeo-Arabic
+jpr: Judeo-Persian
+kbd: Kabardian
+kab: Kabyle
+kac: Kachin
+kal: Kalâtdlisut
+kam: Kamba
+kan: Kannada
+kau: Kanuri
+krc: Karachay-Balkar
+kaa: Kara-Kalpak
+krl: Karelian
+kar: Karen languages
+kas: Kashmiri
+csb: Kashubian
+kaw: Kawi
+kaz: Kazakh
+kha: Khasi
+khm: Khmer
+cam: Khmer
+khi: Khoisan (Other)
+kho: Khotanese
+kik: Kikuyu
+kmb: Kimbundu
+kin: Kinyarwanda
+tlh: Klingon (Artificial language)
+kom: Komi
+kon: Kongo
+kok: Konkani
+kut: Kootenai
+kor: Korean
+kos: Kosraean
+kpe: Kpelle
+kro: Kru (Other)
+kua: Kuanyama
+kum: Kumyk
+kur: Kurdish
+kru: Kurukh
+kus: Kusaie
+kir: Kyrgyz
+lad: Ladino
+lah: Lahndā
+lam: Lamba (Zambia and Congo)
+lao: Lao
+lat: Latin
+lav: Latvian
+lez: Lezgian
+lim: Limburgish
+lin: Lingala
+lit: Lithuanian
+jbo: Lojban (Artificial language)
+nds: Low German
+dsb: Lower Sorbian
+loz: Lozi
+lub: Luba-Katanga
+lua: Luba-Lulua
+lui: Luiseño
+smj: Lule Sami
+lun: Lunda
+luo: Luo (Kenya and Tanzania)
+lus: Lushai
+ltz: Luxembourgish
+mac: Macedonian
+mad: Madurese
+mag: Magahi
+mai: Maithili
+mak: Makasar
+mlg: Malagasy
+mla: Malagasy
+may: Malay
+mal: Malayalam
+mlt: Maltese
+mnc: Manchu
+mdr: Mandar
+man: Mandingo
+mni: Manipuri
+mno: Manobo languages
+glv: Manx
+max: Manx
+mao: Maori
+arn: Mapuche
+mar: Marathi
+chm: Mari
+mah: Marshallese
+mwr: Marwari
+mas: Maasai
+myn: Mayan languages
+men: Mende
+mic: Micmac
+min: Minangkabau
+mwl: Mirandese
+mis: Miscellaneous languages
+moh: Mohawk
+mdf: Moksha
+mol: Moldavian
+mkh: Mon-Khmer (Other)
+lol: Mongo-Nkundu
+mon: Mongolian
+mos: Mooré
+mul: Multiple languages
+mun: Munda (Other)
+nah: Nahuatl
+nau: Nauru
+nav: Navajo
+nbl: Ndebele (South Africa)
+nde: Ndebele (Zimbabwe)
+ndo: Ndonga
+nap: Neapolitan Italian
+nep: Nepali
+new: Newari
+nwc: "Newari, Old"
+nia: Nias
+nic: Niger-Kordofanian (Other)
+ssa: Nilo-Saharan (Other)
+niu: Niuean
+nqo: N'Ko
+nog: Nogai
+zxx: No linguistic content
+nai: North American Indian (Other)
+frr: North Frisian
+sme: Northern Sami
+nso: Northern Sotho
+nor: Norwegian
+nob: Norwegian (Bokmål)
+nno: Norwegian (Nynorsk)
+nub: Nubian languages
+nym: Nyamwezi
+nya: Nyanja
+nyn: Nyankole
+nyo: Nyoro
+nzi: Nzima
+oci: Occitan (post-1500)
+lan: Occitan (post 1500)
+xal: Oirat
+oji: Ojibwa
+non: Old Norse
+peo: Old Persian (ca. 600-400 B.C.)
+ori: Oriya
+orm: Oromo
+gal: Oromo
+osa: Osage
+oss: Ossetic
+oto: Otomian languages
+pal: Pahlavi
+pau: Palauan
+pli: Pali
+pam: Pampanga
+pag: Pangasinan
+pan: Panjabi
+pap: Papiamento
+paa: Papuan (Other)
+per: Persian
+phi: Philippine (Other)
+phn: Phoenician
+pon: Pohnpeian
+pol: Polish
+por: Portuguese
+pra: Prakrit languages
+pro: Provençal (to 1500)
+pus: Pushto
+que: Quechua
+roh: Raeto-Romance
+raj: Rajasthani
+rap: Rapanui
+rar: Rarotongan
+roa: Romance (Other)
+rom: Romani
+rum: Romanian
+run: Rundi
+rus: Russian
+sal: Salishan languages
+sam: Samaritan Aramaic
+smi: Sami
+lap: Sami
+smo: Samoan
+sao: Samoan
+sad: Sandawe
+sag: Sango (Ubangi Creole)
+san: Sanskrit
+sat: Santali
+srd: Sardinian
+sas: Sasak
+sco: Scots
+gla: Scottish Gaelic
+gae: Scottish Gaelic
+sel: Selkup
+sem: Semitic (Other)
+srp: Serbian
+scc: Serbian
+srr: Serer
+shn: Shan
+sna: Shona
+sho: Shona
+iii: Sichuan Yi
+scn: Sicilian Italian
+sid: Sidamo
+sgn: Sign languages
+bla: Siksika
+snd: Sindhi
+sin: Sinhalese
+snh: Sinhalese
+sit: Sino-Tibetan (Other)
+sio: Siouan (Other)
+sms: Skolt Sami
+den: Slavey
+sla: Slavic (Other)
+slo: Slovak
+slv: Slovenian
+sog: Sogdian
+som: Somali
+son: Songhai
+snk: Soninke
+wen: Sorbian (Other)
+sot: Sotho
+sso: Sotho
+sai: South American Indian (Other)
+sma: Southern Sami
+spa: Spanish
+srn: Sranan
+suk: Sukuma
+sux: Sumerian
+sun: Sundanese
+sus: Susu
+swa: Swahili
+ssw: Swazi
+swz: Swazi
+swe: Swedish
+gsw: Swiss German
+syc: Syriac
+syr: "Syriac, Modern"
+tgl: Tagalog
+tag: Tagalog
+tah: Tahitian
+tai: Tai (Other)
+tgk: Tajik
+taj: Tajik
+tmh: Tamashek
+tam: Tamil
+tat: Tatar
+tar: Tatar
+tel: Telugu
+tem: Temne
+ter: Terena
+tet: Tetum
+tha: Thai
+tib: Tibetan
+tig: Tigré
+tir: Tigrinya
+tiv: Tiv
+tli: Tlingit
+tpi: Tok Pisin
+tkl: Tokelauan
+tog: Tonga (Nyasa)
+ton: Tongan
+tru: Truk
+tsi: Tsimshian
+tso: Tsonga
+tsn: Tswana
+tsw: Tswana
+tum: Tumbuka
+tup: Tupi languages
+tur: Turkish
+ota: "Turkish, Ottoman"
+tuk: Turkmen
+tvl: Tuvaluan
+tyv: Tuvinian
+twi: Twi
+udm: Udmurt
+uga: Ugaritic
+uig: Uighur
+ukr: Ukrainian
+umb: Umbundu
+und: Undetermined
+hsb: Upper Sorbian
+urd: Urdu
+uzb: Uzbek
+vai: Vai
+ven: Venda
+vie: Vietnamese
+vol: Volapük
+vot: Votic
+wak: Wakashan languages
+wln: Walloon
+war: Waray
+was: Washoe
+wel: Welsh
+him: Western Pahari languages
+wal: Wolayta
+wol: Wolof
+xho: Xhosa
+sah: Yakut
+yao: Yao (Africa)
+yap: Yapese
+yid: Yiddish
+yor: Yoruba
+ypk: Yupik languages
+znd: Zande languages
+zap: Zapotec
+zza: Zaza
+zen: Zenaga
+zha: Zhuang
+zul: Zulu
+zun: Zuni

--- a/lib/hathifiles_database/translation_maps/place_of_publication.yaml
+++ b/lib/hathifiles_database/translation_maps/place_of_publication.yaml
@@ -1,0 +1,371 @@
+---
+'af ': Afghanistan
+alu: United States -- Alabama
+aku: United States -- Alaska
+'aa ': Albania
+abc: Canada -- Alberta
+'ae ': Algeria
+'as ': American Samoa
+'an ': Andorra
+'ao ': Angola
+'am ': Anguilla
+'ay ': Antarctica
+'aq ': Antigua and Barbuda
+'ag ': Argentina
+azu: United States -- Arizona
+aru: United States -- Arkansas
+'ai ': Armenia (Republic)
+'aw ': Aruba
+'at ': Australia
+'xxa' : Australia
+aca: Australia -- Australian Capital Territory
+'au ': Austria
+'aj ': Azerbaijan
+'bf ': Bahamas
+'ba ': Bahrain
+'bg ': Bangladesh
+'bb ': Barbados
+'bw ': Belarus
+'be ': Belgium
+'bh ': Belize
+'dm ': Benin
+'bm ': Bermuda Islands
+'bt ': Bhutan
+'bo ': Bolivia
+'bn ': Bosnia and Hercegovina
+'bs ': Botswana
+'bv ': Bouvet Island
+'bl ': Brazil
+bcc: Canada -- British Columbia
+'bi ': British Indian Ocean Territory
+'vb ': British Virgin Islands
+'bx ': Brunei
+'bu ': Bulgaria
+'uv ': Burkina Faso
+'br ': Burma
+'bd ': Burundi
+cau: United States -- California
+'cb ': Cambodia
+'cm ': Cameroon
+xxc: Canada
+'cv ': Cabo Verde
+'ca ': Caribbean Netherlands
+'cj ': Cayman Islands
+'cx ': Central African Republic
+'cd ': Chad
+'cl ': Chile
+'cc ': China
+'ch ': 'China (Republic : 1949- )'
+'xa ': Christmas Island (Indian Ocean)
+'xb ': Cocos (Keeling) Islands
+'ck ': Colombia
+cou: United States -- Colorado
+'cq ': Comoros
+'cf ': Congo (Brazzaville)
+'cg ': Congo (Democratic Republic)
+ctu: United States -- 'Connecticut '
+'cw ': Cook Islands
+xga: Australia -- Coral Sea Islands Territory
+'cr ': Costa Rica
+'iv ': Côte d'Ivoire
+'ci ': Croatia
+'cu ': Cuba
+'co ': Curaçao
+'cy ': Cyprus
+'xr ': Czech Republic
+deu: United States -- Delaware
+'dk ': Denmark
+dcu: United States -- District of Columbia
+'ft ': Djibouti
+'dq ': Dominica
+'dr ': Dominican Republic
+'ec ': Ecuador
+'ua ': Egypt
+'es ': El Salvador
+enk: United Kingdom -- England
+'eg ': Equatorial Guinea
+'ea ': Eritrea
+'er ': Estonia
+'et ': Ethiopia
+'fk ': Falkland Islands
+'fa ': Faroe Islands
+'fj ': Fiji
+'fi ': Finland
+flu: United States -- Florida
+'fr ': France
+'fg ': French Guiana
+'fp ': French Polynesia
+'go ': Gabon
+'gm ': Gambia
+'gz ': Gaza Strip
+gau: United States -- Georgia
+'gs ': Georgia (Republic)
+'gw ': Germany
+'gh ': Ghana
+'gi ': Gibraltar
+'gr ': Greece
+'gl ': Greenland
+'gd ': Grenada
+'gp ': Guadeloupe
+'gu ': Guam
+'gt ': Guatemala
+'gv ': Guinea
+'pg ': Guinea-Bissau
+'gy ': Guyana
+'ht ': Haiti
+hiu: United States -- Hawaii
+'hm ': Heard and McDonald Islands
+'ho ': Honduras
+'hu ': Hungary
+'ic ': Iceland
+idu: United States -- Idaho
+ilu: United States -- Illinois
+'ii ': India
+inu: United States -- Indiana
+'io ': Indonesia
+iau: United States -- Iowa
+'ir ': Iran
+'iq ': Iraq
+'iy ': Iraq-Saudi Arabia Neutral Zone
+'ie ': Ireland
+'is ': Israel
+'it ': Italy
+'jm ': Jamaica
+'ja ': Japan
+'ji ': Johnston Atoll
+'jo ': Jordan
+ksu: United States -- Kansas
+'kz ': Kazakhstan
+kyu: United States -- Kentucky
+'ke ': Kenya
+'gb ': Kiribati
+'kn ': Korea (North)
+'ko ': Korea (South)
+'kv ': Kosovo
+'ku ': Kuwait
+'kg ': Kyrgyzstan
+'ls ': Laos
+'lv ': Latvia
+'le ': Lebanon
+'lo ': Lesotho
+'lb ': Liberia
+'ly ': Libya
+'lh ': Liechtenstein
+'li ': Lithuania
+lau: United States -- Louisiana
+'lu ': Luxembourg
+'xn ': Macedonia
+'mg ': Madagascar
+meu: United States -- Maine
+'mw ': Malawi
+'my ': Malaysia
+'xc ': Maldives
+'ml ': Mali
+'mm ': Malta
+mbc: Canada -- Manitoba
+'xe ': Marshall Islands
+'mq ': Martinique
+mdu: United States -- Maryland
+mau: United States -- Massachusetts
+'mu ': Mauritania
+'mf ': Mauritius
+'ot ': Mayotte
+'mx ': Mexico
+miu: United States -- Michigan
+'fm ': Micronesia (Federated States)
+'xf ': Midway Islands
+mnu: United States -- Minnesota
+msu: United States -- Mississippi
+mou: United States -- Missouri
+'mv ': Moldova
+'mc ': Monaco
+'mp ': Mongolia
+mtu: United States -- Montana
+'mo ': Montenegro
+'mj ': Montserrat
+'mr ': Morocco
+'mz ': Mozambique
+'sx ': Namibia
+'nu ': Nauru
+nbu: United States -- Nebraska
+'np ': Nepal
+'ne ': Netherlands
+nvu: United States -- Nevada
+nkc: Canada -- New Brunswick
+'nl ': New Caledonia
+nhu: United States -- New Hampshire
+nju: United States -- New Jersey
+nmu: United States -- New Mexico
+xna: Australia -- New South Wales
+nyu: United States -- New York (State)
+'nz ': New Zealand
+nfc: Canada -- Newfoundland and Labrador
+'nq ': Nicaragua
+'ng ': Niger
+'nr ': Nigeria
+'xh ': Niue
+'xx ': No place, unknown, or undetermined
+'nx ': 'Norfolk Island '
+ncu: United States -- North Carolina
+ndu: United States -- North Dakota
+nik: United Kingdom -- Northern Ireland
+'nw ': Northern Mariana Islands
+xoa: Australia -- Northern Territory
+ntc: Canada -- Northwest Territories
+'no ': Norway
+nsc: Canada -- Nova Scotia
+nuc: Canada -- Nunavut
+ohu: United States -- Ohio
+oku: United States -- Oklahoma
+'mk ': Oman
+onc: Canada -- Ontario
+oru: United States -- Oregon
+'pk ': Pakistan
+'pw ': Palau
+'pn ': Panama
+'pp ': Papua New Guinea
+'pf ': Paracel Islands]
+'py ': Paraguay
+pau: United States -- Pennsylvania
+'pe ': Peru
+'ph ': Philippines
+'pc ': Pitcairn Island
+'pl ': Poland
+'po ': Portugal
+pic: Canada -- Prince Edward Island
+'pr ': Puerto Rico
+'qa ': Qatar
+quc: Canada -- Québec (Province)
+qea: Australia -- Queensland
+'re ': Réunion
+riu: United States -- Rhode Island
+'rm ': Romania
+'ru ': Russia (Federation)
+'rw ': Rwanda
+'sc ': Saint-Barthélemy
+'xj ': Saint Helena
+'xd ': Saint Kitts-Nevis
+'xk ': Saint Lucia
+'st ': Saint-Martin
+'xl ': Saint Pierre and Miquelon
+'xm ': Saint Vincent and the Grenadines
+'ws ': Samoa
+'sm ': San Marino
+'sf ': Sao Tome and Principe
+snc: Canada -- Saskatchewan
+'su ': Saudi Arabia
+stk: United Kingdom -- Scotland
+'sg ': Senegal
+'rb ': Serbia
+'se ': Seychelles
+'sl ': Sierra Leone
+'si ': Singapore
+'sn ': Sint Maarten
+'xo ': Slovakia
+'xv ': Slovenia
+'bp ': Solomon Islands
+'so ': Somalia
+'sa ': South Africa
+xra: Australia -- South Australia
+scu: United States -- South Carolina
+sdu: United States -- South Dakota
+'xs ': South Georgia and the South Sandwich Islands
+'sd ': South Sudan
+'sp ': Spain
+'sh ': Spanish North Africa
+'xp ': Spratly Island
+'ce ': Sri Lanka
+'sj ': Sudan
+'sr ': Surinam
+'sq ': Swaziland
+'sw ': Sweden
+'sz ': Switzerland
+'sy ': Syria
+'ta ': Tajikistan
+'tz ': Tanzania
+tma: Australia -- Tasmania
+tnu: United States -- Tennessee
+'fs ': Terres australes et antarctiques françaises
+txu: United States -- Texas
+'th ': Thailand
+'em ': Timor-Leste
+'tg ': Togo
+'tl ': Tokelau
+'to ': Tonga
+'tr ': Trinidad and Tobago
+'ti ': Tunisia
+'tu ': Turkey
+'tk ': Turkmenistan
+'tc ': Turks and Caicos Islands
+'tv ': Tuvalu
+'ug ': Uganda
+'un ': Ukraine
+'ts ': United Arab Emirates
+xxk: United Kingdom
+uik: United Kingdom -- United Kingdom Misc. Islands
+xxu: United States
+'uc ': United States Misc. Caribbean Islands
+'up ': United States Misc. Pacific Islands
+'uy ': Uruguay
+utu: United States -- Utah
+'uz ': Uzbekistan
+'nn ': Vanuatu
+'vp ': Various places
+'vc ': Vatican City
+'ve ': Venezuela
+vtu: United States -- Vermont
+vra: Australia -- Victoria
+'vm ': Vietnam
+'vi ': Virgin Islands of the United States
+vau: United States -- Virginia
+'wk ': Wake Island
+wlk: United Kingdom -- Wales
+'wf ': Wallis and Futuna
+wau: United States -- Washington (State)
+'wj ': West Bank of the Jordan River
+wvu: United States -- West Virginia
+wea: Australia -- Western Australia
+'ss ': 'Western Sahara '
+wiu: United States -- Wisconsin
+wyu: United States -- Wyoming
+'ye ': Yemen
+ykc: Canada -- Yukon Territory
+'za ': Zambia
+'rh ': Zimbabwe
+'xi ': Saint Kitts-Nevis-Anguilla
+air: Armenian S.S.R.
+'ur ': Soviet Union
+'ac ': Ashmore and Cartier Islands
+ajr: 'Azerbaijan S.S.R. '
+bwr: Byelorussian S.S.R.
+'na ': Netherlands Antilles
+'hk ': Hong Kong
+'mh ': Macao
+'cs ': Czechoslovakia
+gsr: Georgian S.S.R.
+'ge ': Germany (East)
+'wb ': West Berlin
+'sv ': Swan Islands
+'sk ': Sikkim
+'iw ': Israel-Jordan Demilitarized Zones
+'iu ': Israel-Syria Demilitarized Zones
+'ry ': Ryukyu Islands, Southern
+kzr: Kazakh S.S.R.
+'gn ': Gilbert and Ellice Islands
+'cp ': Canton and Enderbury Islands
+'ln ': Central and Southern Line Islands
+kgr: Kirghiz S.S.R.
+'tt ': Trust Territory of the Pacific Islands
+mvr: Moldavian S.S.R.
+'yu ': Yugoslavia
+'jn ': Jan Mayen
+'sb ': Svalbard
+'cz ': Canal Zone
+rur: Russian S.F.S.R.
+tar: Tajik S.S.R.
+'pt ': Portuguese Timor
+tkr: Turkmen S.S.R.
+uzr: Uzbek S.S.R.
+'vn ': Vietnam, North
+'vs ': Vietnam, South
+'ys ': Yemen (People's Democratic Republic)


### PR DESCRIPTION
This also creates some tables needed for mapping from codes in hathifiles to full values for display. I decided to use a separate class for this rather than the migrations in part because not all use cases need the mapping tables and in part because it seemed somewhat simpler and easier to test to do it this way.

This does *not* include every table needed by `hf_summary_expanded` -- in particular it doesn't include `ht_institutions` or `ht_sources`. I waffled with loading something using https://www.hathitrust.org/files/ht_institutions.tsv, but we don't have anything similar for the static rights `sources` values. While having that mapping publicly available would probably be of use too, I didn't want to expand the scope for this too much.

The summary tables refresh doesn't have tests, primarily because it's just a glorified way of running the SQL queries. Because of the issue of `ht_institutions` and `sources` above, this also won't work out of the box. I ran it to test by changing to using `db-image`, but I'm hesitant to do that in part because this gem does have some outside usage by HT members.

To test, update `docker-compose.yml`:

```patch
diff --git a/docker-compose.yml b/docker-compose.yml
index 56d6b2a..c7aace7 100644
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ services:
       MARIADB_HATHIFILES_RW_PASSWORD: "ht_rights"
       MARIADB_HATHIFILES_RW_HOST: "mariadb"
       MARIADB_HATHIFILES_RW_DATABASE: "ht"
+      MARIADB_HATHIFILES_RW_EXTRA_FLAGS: "--skip-ssl"
       HATHIFILES_DIR: "/usr/src/app/spec/data"
       PUSHGATEWAY: http://pushgateway:9091
     volumes:
@@ -27,7 +28,7 @@ services:
       mariadb: *healthy
 
   mariadb:
-    image: mariadb:latest
+    image: ghcr.io/hathitrust/db-image:latest
     #volumes:
     #  - ./sql/100_rights_log.sql:/docker-entrypoint-initdb.d/100_rights_log.sql
     restart: always
```

Then:

```bash
bundle exec run --rm test bundle exec rspec
```

FBFW, thas will leave a sample `hf` table with 100 rows in place.

Then:

```bash
bundle exec run --rm test bundle exec exe/refresh_summary_table
```

You should then be able to see the `hf_summary` and `hf_summary_expanded` tables in the database.